### PR TITLE
Make consume() return a Result instead of a bool

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,19 @@
+use std::time::Duration;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The configured rate-limit has been exceeded. New attempts might succeed after the specified delay.
+    RetryAfter(Duration),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::RetryAfter(duration) => {
+                write!(f, "Retry after {:.1} seconds", duration.as_secs_f64())
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod error;
 mod rate_limiter;
 mod token_bucket;
 

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::time::{Duration, Instant};
 
+use crate::error::Error;
 use crate::TokenBucket;
 
 pub struct RateLimiter<'a, K> {
@@ -26,11 +27,11 @@ impl<'a, K: Eq + Hash> RateLimiter<'a, K> {
             .insert(key, TokenBucket::with_timer(limit, interval, self.clock));
     }
 
-    pub fn consume(&self, key: K, tokens: usize) -> bool {
+    pub fn consume(&self, key: K, tokens: usize) -> Result<(), Error> {
         self.buckets
             .get(&key)
             .map(|bucket| bucket.consume(tokens))
-            .unwrap_or(true)
+            .unwrap_or(Ok(()))
     }
 }
 
@@ -49,15 +50,16 @@ mod tests {
     fn new() {
         let mut limiter = RateLimiter::new();
 
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("B", 1), true);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("B", 1), Ok(()));
 
         limiter.set_limit("A", 3, Duration::from_secs(60));
 
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        // we don't mock time in this test case, so checking the retry-after delay would be unreliable
+        assert!(limiter.consume("A", 1).is_err());
     }
 
     #[test]
@@ -68,12 +70,18 @@ mod tests {
         let mut limiter = RateLimiter::with_timer(&clock);
         limiter.set_limit("A", 1, Duration::from_secs(1));
 
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
     }
 
     #[test]
@@ -84,16 +92,22 @@ mod tests {
         let mut limiter = RateLimiter::with_timer(&clock);
         limiter.set_limit("A", 3, Duration::from_secs(1));
 
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
     }
 
     #[test]
@@ -104,15 +118,24 @@ mod tests {
         let mut limiter = RateLimiter::with_timer(&clock);
         limiter.set_limit("A", 1, Duration::from_secs(3));
 
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_secs(3)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(2);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(3);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_secs(3)))
+        );
     }
 
     #[test]
@@ -126,40 +149,52 @@ mod tests {
 
         // consume first token
         *now.lock().unwrap() = t0;
-        assert_eq!(limiter.consume("A", 1), true);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
 
         // consume second token
         *now.lock().unwrap() = t0 + Duration::from_millis(50);
-        assert_eq!(limiter.consume("A", 1), true);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
 
         // consume third & fourth tokens
         *now.lock().unwrap() = t0 + Duration::from_millis(150);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
 
         // ensure we are out of tokens
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_millis(100)))
+        );
 
         // one token is not yet replenished
         *now.lock().unwrap() = t0 + Duration::from_millis(249);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_millis(1)))
+        );
 
         // one token is replenished
         *now.lock().unwrap() = t0 + Duration::from_millis(250);
-        assert_eq!(limiter.consume("A", 1), true);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
 
         // ensure we are out of tokens again
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_millis(250)))
+        );
 
         // two tokens are replenished
         *now.lock().unwrap() = t0 + Duration::from_millis(750);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_millis(250)))
+        );
     }
 
     #[test]
-    fn weight_gt_one() {
+    fn consume_gt_one() {
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
 
@@ -167,21 +202,33 @@ mod tests {
         limiter.set_limit("A", 3, Duration::from_secs(1));
 
         // consume all tokens at once
-        assert_eq!(limiter.consume("A", 3), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 3), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
 
         // sequentially consume tokens
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(limiter.consume("A", 2), true);
-        assert_eq!(limiter.consume("A", 2), false);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 2), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 2),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
 
         // two tokens are replenished
         *now.lock().unwrap() += Duration::from_millis(700);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_nanos(299_999_998)))
+        );
     }
 
     #[test]
@@ -194,26 +241,44 @@ mod tests {
         limiter.set_limit("B", 1, Duration::from_secs(2));
 
         // consume tokens in A and B
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
-        assert_eq!(limiter.consume("B", 1), true);
-        assert_eq!(limiter.consume("B", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_millis(500)))
+        );
+        assert_eq!(limiter.consume("B", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("B", 1),
+            Err(Error::RetryAfter(Duration::from_secs(2)))
+        );
 
         // tokens in A are replenished, but not in B
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
-        assert_eq!(limiter.consume("B", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_millis(500)))
+        );
+        assert_eq!(
+            limiter.consume("B", 1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
 
         // tokens in A and B are replenished
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), true);
-        assert_eq!(limiter.consume("A", 1), false);
-        assert_eq!(limiter.consume("B", 1), true);
-        assert_eq!(limiter.consume("B", 1), false);
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(limiter.consume("A", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("A", 1),
+            Err(Error::RetryAfter(Duration::from_millis(500)))
+        );
+        assert_eq!(limiter.consume("B", 1), Ok(()));
+        assert_eq!(
+            limiter.consume("B", 1),
+            Err(Error::RetryAfter(Duration::from_secs(2)))
+        );
     }
 
     #[test]
@@ -232,16 +297,25 @@ mod tests {
         limiter.set_limit((MyHttpVerb::GET, "/foobar"), 3, Duration::from_secs(1));
         limiter.set_limit((MyHttpVerb::GET, "/spam"), 2, Duration::from_secs(1));
 
-        assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), true);
-        assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), true);
-        assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), true);
-        assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), false);
+        assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), Ok(()));
+        assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), Ok(()));
+        assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), Ok(()));
+        assert_eq!(
+            limiter.consume((MyHttpVerb::GET, "/foobar"), 1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
 
-        assert_eq!(limiter.consume((MyHttpVerb::PUT, "/foobar"), 1), true);
-        assert_eq!(limiter.consume((MyHttpVerb::PUT, "/foobar"), 1), false);
+        assert_eq!(limiter.consume((MyHttpVerb::PUT, "/foobar"), 1), Ok(()));
+        assert_eq!(
+            limiter.consume((MyHttpVerb::PUT, "/foobar"), 1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
 
-        assert_eq!(limiter.consume((MyHttpVerb::GET, "/spam"), 1), true);
-        assert_eq!(limiter.consume((MyHttpVerb::GET, "/spam"), 1), true);
-        assert_eq!(limiter.consume((MyHttpVerb::GET, "/spam"), 1), false);
+        assert_eq!(limiter.consume((MyHttpVerb::GET, "/spam"), 1), Ok(()));
+        assert_eq!(limiter.consume((MyHttpVerb::GET, "/spam"), 1), Ok(()));
+        assert_eq!(
+            limiter.consume((MyHttpVerb::GET, "/spam"), 1),
+            Err(Error::RetryAfter(Duration::from_millis(500)))
+        );
     }
 }

--- a/src/token_bucket.rs
+++ b/src/token_bucket.rs
@@ -1,6 +1,8 @@
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use crate::error::Error;
+
 pub struct TokenBucket<'a> {
     time_per_token: usize,
     interval: Duration,
@@ -28,7 +30,7 @@ impl<'a> TokenBucket<'a> {
         }
     }
 
-    pub fn consume(&self, tokens: usize) -> bool {
+    pub fn consume(&self, tokens: usize) -> Result<(), Error> {
         let now = (self.clock)();
 
         let mut lock = self.last_replenished_at.lock().unwrap();
@@ -39,10 +41,10 @@ impl<'a> TokenBucket<'a> {
 
         let required_time = std::cmp::max(interval_start, last_replenished_at) + token_delay;
         if required_time > now {
-            false
+            Err(Error::RetryAfter(required_time - now))
         } else {
             *lock = Some(required_time);
-            true
+            Ok(())
         }
     }
 }
@@ -57,10 +59,11 @@ mod tests {
     fn new() {
         let bucket = TokenBucket::new(3, Duration::from_secs(60));
 
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        // we don't mock time in this test case, so checking the retry-after delay would be unreliable
+        assert!(bucket.consume(1).is_err());
     }
 
     #[test]
@@ -69,12 +72,18 @@ mod tests {
         let clock = || *now.lock().unwrap();
         let bucket = TokenBucket::with_timer(1, Duration::from_secs(1), &clock);
 
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
     }
 
     #[test]
@@ -83,16 +92,22 @@ mod tests {
         let clock = || *now.lock().unwrap();
         let bucket = TokenBucket::with_timer(3, Duration::from_secs(1), &clock);
 
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
     }
 
     #[test]
@@ -101,15 +116,24 @@ mod tests {
         let clock = || *now.lock().unwrap();
         let bucket = TokenBucket::with_timer(1, Duration::from_secs(3), &clock);
 
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_secs(3)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(2);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_secs(1)))
+        );
 
         *now.lock().unwrap() += Duration::from_secs(3);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_secs(3)))
+        );
     }
 
     #[test]
@@ -121,59 +145,83 @@ mod tests {
 
         // consume first token
         *now.lock().unwrap() = t0;
-        assert_eq!(bucket.consume(1), true);
+        assert_eq!(bucket.consume(1), Ok(()));
 
         // consume second token
         *now.lock().unwrap() = t0 + Duration::from_millis(50);
-        assert_eq!(bucket.consume(1), true);
+        assert_eq!(bucket.consume(1), Ok(()));
 
         // consume third & fourth tokens
         *now.lock().unwrap() = t0 + Duration::from_millis(150);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
 
         // ensure we are out of tokens
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_millis(100)))
+        );
 
         // one token is not yet replenished
         *now.lock().unwrap() = t0 + Duration::from_millis(249);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_millis(1)))
+        );
 
         // one token is replenished
         *now.lock().unwrap() = t0 + Duration::from_millis(250);
-        assert_eq!(bucket.consume(1), true);
+        assert_eq!(bucket.consume(1), Ok(()));
 
         // ensure we are out of tokens again
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_millis(250)))
+        );
 
         // two tokens are replenished
         *now.lock().unwrap() = t0 + Duration::from_millis(750);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_millis(250)))
+        );
     }
 
     #[test]
-    fn weight_gt_one() {
+    fn consume_gt_one() {
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
         let bucket = TokenBucket::with_timer(3, Duration::from_secs(1), &clock);
 
         // consume all tokens at once
-        assert_eq!(bucket.consume(3), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(3), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
 
         // sequentially consume tokens
         *now.lock().unwrap() += Duration::from_secs(1);
-        assert_eq!(bucket.consume(2), true);
-        assert_eq!(bucket.consume(2), false);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(2), Ok(()));
+        assert_eq!(
+            bucket.consume(2),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_nanos(333_333_332)))
+        );
 
         // two tokens are replenished
         *now.lock().unwrap() += Duration::from_millis(700);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), true);
-        assert_eq!(bucket.consume(1), false);
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(bucket.consume(1), Ok(()));
+        assert_eq!(
+            bucket.consume(1),
+            Err(Error::RetryAfter(Duration::from_nanos(299_999_998)))
+        );
     }
 }


### PR DESCRIPTION
The primary use case for this is so that we can return a custom error, which would tell the caller for how long they need to wait for the next attempt to succeed (think Retry-After in HTTP's Too Many Requests status).

We might come up with additional error conditions later (e.g. treat a rate-limit of 0 as completely blocking a giving key, in which case retrying does not make sense).

This is much easier now that we removed all the floating point arithmetic and use a fixed clock in tests.