### PR TITLE
Allow to block requests by specifying a rate-limit of 0

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,11 @@
 use std::time::Duration;
 
+/// Error type describing various possible conditions for why requests are rejected.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
+    /// The corresponding entity is completely blocked. New attempts will also result in failures.
+    Blocked,
+
     /// The configured rate-limit has been exceeded. New attempts might succeed after the specified delay.
     RetryAfter(Duration),
 }
@@ -9,6 +13,7 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Error::Blocked => write!(f, "Entity is blocked"),
             Error::RetryAfter(duration) => {
                 write!(f, "Retry after {:.1} seconds", duration.as_secs_f64())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ mod error;
 mod rate_limiter;
 mod token_bucket;
 
+pub use error::Error;
 pub use rate_limiter::RateLimiter;
 pub use token_bucket::TokenBucket;

--- a/src/token_bucket.rs
+++ b/src/token_bucket.rs
@@ -3,6 +3,43 @@ use std::time::{Duration, Instant};
 
 use crate::error::Error;
 
+/// Implementation of the [token bucket](https://en.wikipedia.org/wiki/Token_bucket)
+/// rate-limiting algorithm.
+///
+/// The algorithm is based on the analogy with a fixed capacity *bucket* to
+/// which abstract *tokens* are added with a constant rate up until the bucket
+/// is full.
+///
+/// To implement rate-limiting, each request entering the system is assigned
+/// a *cost* in terms of the number of tokens, and it tries to consume that
+/// many tokens from the bucket:
+///
+/// * if the bucket has the sufficient number of tokens available, they are *consumed*,
+///   and the request is allowed to go through
+///
+/// * otherwise, the request is rejected. New requests continue to be rejected until
+///   the bucket is refilled
+///
+/// Because tokens are added to the bucket with a constant rate over the specified
+/// interval of time, this effectively limits requests to the system to the same rate.
+///
+/// Bucket capacity and token replenishment rate are specified at bucket creation time.
+///
+/// ```
+/// use std::time::Duration;
+/// use youshallnotpass::{TokenBucket, Error};
+///
+/// // create a bucket that allows to consume 3 tokens every 60 seconds
+/// let bucket = TokenBucket::new(3, Duration::from_secs(60));
+/// assert!(bucket.consume(1).is_ok());
+/// assert!(bucket.consume(1).is_ok());
+/// assert!(bucket.consume(1).is_ok());
+/// // requests exceeding the configured rate-limit are rejected. The error will specify
+/// // how much time the caller has to wait before retrying
+/// assert!(matches!(bucket.consume(1), Err(Error::RetryAfter(duration))));
+/// ```
+///
+/// Generated tokens can be consumed all at once or over time.
 pub struct TokenBucket<'a> {
     time_per_token: usize,
     interval: Duration,
@@ -11,28 +48,89 @@ pub struct TokenBucket<'a> {
 }
 
 impl<'a> TokenBucket<'a> {
+    /// Create a new [`TokenBucket`] with `limit` tokens generated with a constant
+    /// rate over the specified `interval` of time.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use youshallnotpass::TokenBucket;
+    ///
+    /// // create a bucket that allows to consume 2 tokens every 30 seconds
+    /// let bucket = TokenBucket::new(2, Duration::from_secs(30));
+    /// assert!(bucket.consume(1).is_ok());
+    /// assert!(bucket.consume(1).is_ok());
+    /// assert!(bucket.consume(1).is_err());
+    /// ```
+    ///
+    /// Specifying the `limit` (or `interval`) of 0 has a meaning of blocking a
+    /// given entity: no tokens can be consumed in that case, regardless of how
+    /// much time passes or how many attempts are performed.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use youshallnotpass::{TokenBucket, Error};
+    ///
+    /// // create a new bucket that does not allow to consume any tokens
+    /// let bucket = TokenBucket::new(0, Duration::from_secs(60));
+    /// assert!(matches!(bucket.consume(1), Err(Error::Blocked)));
+    /// ```
     pub fn new(limit: usize, interval: Duration) -> Self {
         TokenBucket::with_timer(limit, interval, &Instant::now)
     }
 
+    /// Same as [`TokenBucket::new()`], but allows to override the internal clock,
+    /// which is mainly useful in tests.
     pub(crate) fn with_timer(
         limit: usize,
         interval: Duration,
         clock: &'a (dyn Fn() -> Instant + Sync),
     ) -> Self {
-        assert!(limit > 0, "limit must be a positive integer");
-
         TokenBucket {
-            time_per_token: interval.as_nanos() as usize / limit,
+            time_per_token: if limit > 0 {
+                interval.as_nanos() as usize / limit
+            } else {
+                0
+            },
             interval,
             last_replenished_at: Mutex::new(None),
             clock,
         }
     }
 
+    /// Try to consume the specified number of `tokens` from the bucket.
+    ///
+    /// If the bucket has the sufficient number of tokens available, they are *consumed*
+    /// and `Ok(())` is returned.
+    ///
+    /// If the bucket has fewer tokens available, the internal state is *not* modified,
+    /// and [`Error::RetryAfter`] is returned. The error will specify how much time the
+    /// caller has to wait before trying to call [`TokenBucket::consume()`] with the
+    /// same arguments again. Retrying the operation earlier will result in the same error.
+    ///
+    /// If the bucket has a limit of 0 tokens, [`Error::Blocked`] is always returned instead,
+    /// regardless of how much time the caller waits between attempts.
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use youshallnotpass::{TokenBucket, Error};
+    ///
+    /// // create a new bucket that allows to consume 3 tokens every 60 seconds
+    /// let bucket = TokenBucket::new(3, Duration::from_secs(60));
+    /// assert!(bucket.consume(1).is_ok());
+    /// assert!(bucket.consume(1).is_ok());
+    /// assert!(bucket.consume(1).is_ok());
+    /// assert!(matches!(bucket.consume(1), Err(Error::RetryAfter(duration))));
+    ///
+    /// // create a new bucket that does not allow to consume any tokens
+    /// let bucket = TokenBucket::new(0, Duration::from_secs(60));
+    /// assert!(matches!(bucket.consume(1), Err(Error::Blocked)));
+    /// ```
     pub fn consume(&self, tokens: usize) -> Result<(), Error> {
-        let now = (self.clock)();
+        if self.time_per_token == 0 {
+            return Err(Error::Blocked);
+        }
 
+        let now = (self.clock)();
         let mut lock = self.last_replenished_at.lock().unwrap();
 
         let interval_start = now.checked_sub(self.interval).unwrap_or(now);
@@ -63,7 +161,29 @@ mod tests {
         assert_eq!(bucket.consume(1), Ok(()));
         assert_eq!(bucket.consume(1), Ok(()));
         // we don't mock time in this test case, so checking the retry-after delay would be unreliable
-        assert!(bucket.consume(1).is_err());
+        assert!(matches!(bucket.consume(1), Err(Error::RetryAfter(_))));
+    }
+
+    #[test]
+    fn blocked_limit() {
+        let bucket = TokenBucket::new(0, Duration::from_secs(60));
+
+        // tokens are not being added to the bucket; the entity is effectively blocked,
+        // and retries are useless
+        assert_eq!(bucket.consume(1), Err(Error::Blocked));
+        assert_eq!(bucket.consume(1), Err(Error::Blocked));
+        assert_eq!(bucket.consume(1), Err(Error::Blocked));
+    }
+
+    #[test]
+    fn blocked_duration() {
+        let bucket = TokenBucket::new(42, Duration::from_secs(0));
+
+        // tokens are not being added to the bucket; the entity is effectively blocked,
+        // and retries are useless
+        assert_eq!(bucket.consume(1), Err(Error::Blocked));
+        assert_eq!(bucket.consume(1), Err(Error::Blocked));
+        assert_eq!(bucket.consume(1), Err(Error::Blocked));
     }
 
     #[test]


### PR DESCRIPTION
As an alternative to rate-limiting requests, let's allow to completely *block* a given entity by specifying the limit of 0. The practical difference is that a different error should be returned in this case to emphasize the fact that there is no sense for the caller to retry requests as they will always be rejected.

As a side benefit, this allows us to gracefully handle the condition when a limit of 0 is specified as opposed to triggering a panic.

While we are at this, add documentation for `Error` and `TokenBucket` types.