### PR TITLE
Add a basic benchmark for TokenBucket::consume()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,10 @@ repository = "https://github.com/ikalnytskyi/youshallnotpass"
 license = "MIT"
 keywords = ["rate-limiter", "token-bucket"] 
 categories = ["algorithms", "data-structures"] 
+
+[dev-dependencies]
+criterion = "0.4.0"
+
+[[bench]]
+name = "benchmarks"
+harness = false  # disable the standard test harness, as we want to use the one provided by criterion

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,0 +1,15 @@
+use std::time::Duration;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use youshallnotpass::TokenBucket;
+
+pub fn tokenbucket_consume(c: &mut Criterion) {
+    let bucket = TokenBucket::new(10, Duration::from_secs(600));
+    c.bench_function("TokenBucket::consume(1)", |b| {
+        b.iter(|| bucket.consume(black_box(1)))
+    });
+}
+
+criterion_group!(benches, tokenbucket_consume);
+criterion_main!(benches);


### PR DESCRIPTION
* Run with `$ cargo bench`
* This uses https://docs.rs/criterion/latest/criterion/ which performs a statistical test to dismiss insignificant changes and outliers
* To get better consistency use `taskset` to prevent migrations between CPU threads: `$ taskset -a -c 1 cargo bench`
* https://github.com/bheisler/criterion.rs/blob/master/book/src/faq.md#when-should-i-use-criterionblack_box

Example run:

```
> taskset -a -c 1 cargo bench
    Finished bench [optimized] target(s) in 0.02s
     Running unittests src/lib.rs (target/release/deps/youshallnotpass-4a8793a0e5ce478c)

running 14 tests
test rate_limiter::tests::capacity_gt_one ... ignored
test rate_limiter::tests::capacity_is_one ... ignored
test rate_limiter::tests::compound_key ... ignored
test rate_limiter::tests::consume_gt_one ... ignored
test rate_limiter::tests::consume_over_time ... ignored
test rate_limiter::tests::multiple_buckets ... ignored
test rate_limiter::tests::new ... ignored
test rate_limiter::tests::period_gt_one ... ignored
test token_bucket::tests::capacity_gt_one ... ignored
test token_bucket::tests::capacity_is_one ... ignored
test token_bucket::tests::consume_gt_one ... ignored
test token_bucket::tests::consume_over_time ... ignored
test token_bucket::tests::new ... ignored
test token_bucket::tests::period_gt_one ... ignored

test result: ok. 0 passed; 0 failed; 14 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/benchmarks.rs (target/release/deps/benchmarks-ccbc1633524ac3d5)
TokenBucket::consume(1) time:   [24.844 ns 24.928 ns 25.034 ns]
                        change: [-0.6872% -0.2202% +0.2710%] (p = 0.38 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe
```