### PR TITLE
Add builder for constructing RateLimiter instance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,5 @@ mod rate_limiter;
 mod token_bucket;
 
 pub use error::Error;
-pub use rate_limiter::RateLimiter;
+pub use rate_limiter::{RateLimiter, RateLimiterBuilder};
 pub use token_bucket::TokenBucket;

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -5,28 +5,116 @@ use std::time::{Duration, Instant};
 use crate::error::Error;
 use crate::TokenBucket;
 
+/// An object providing rate limiting functionality.
+///
+/// A rate limiter controls how frequently some event, such as an HTTP request,
+/// is allowed to happen. Rate limiting is commonly used as a defensive measure
+/// to protect services from excessive use (intended or not) and maintain their
+/// availability.
+///
+/// A [`RateLimiter`] instance can be used to set how many times an event is
+/// allowed to happen (`limit`) within a given period of time (`interval`). If
+/// no such policy is set for an event, the event is always allowed.
+///
+/// Once constructed, a `RateLimiter` instance is safe to be used from multiple
+/// threads.
+///
+/// Under the hood the token bucket algorithm is used. See [`TokenBucket`] for
+/// details.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use youshallnotpass::{RateLimiter, Error};
+///
+/// let limiter = RateLimiter::configure()
+///     .limit("A", 2, Duration::from_secs(60))
+///     .limit("B", 3, Duration::from_secs(60))
+///     .done();
+///
+/// assert_eq!(limiter.consume("A", 1), Ok(()));
+/// assert_eq!(limiter.consume("A", 1), Ok(()));
+///
+/// assert!(matches!(limiter.consume("A", 1), Err(Error::RetryAfter(_))));
+/// assert!(matches!(limiter.consume("B", 5), Err(Error::RetryAfter(_))));
+/// ```
 pub struct RateLimiter<'a, K> {
     buckets: HashMap<K, TokenBucket<'a>>,
-    clock: &'a (dyn Fn() -> Instant + Sync),
 }
 
-impl<'a, K: Eq + Hash> RateLimiter<'a, K> {
-    pub fn new() -> Self {
+impl<'a, K> RateLimiter<'a, K> {
+    /// Constructs a new `RateLimiterBuilder` object.
+    ///
+    /// A returned instance of [`RateLimiterBuilder`] can be used to set
+    /// limiting policies and construct an instance of `RateLimiter` via
+    /// [`limit`] and [`done`] functions. See documentation of corresponding
+    /// functions for details.
+    ///
+    /// [`limit`]: RateLimiterBuilder::limit
+    /// [`done`]: RateLimiterBuilder::done
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use youshallnotpass::RateLimiter;
+    ///
+    /// let builder = RateLimiter::<&str>::configure();
+    /// ```
+    #[inline]
+    pub fn configure() -> RateLimiterBuilder<'a, K> {
         Self::with_timer(&Instant::now)
     }
 
-    fn with_timer(clock: &'a (dyn Fn() -> Instant + Sync)) -> Self {
-        Self {
-            buckets: HashMap::new(),
+    /// Constructs a new `RateLimiterBuilder` object with custom `clock`
+    /// function.
+    ///
+    /// Unlike [`configure`], this function receives custom `clock` function to
+    /// be used instead of [`Instant::now`]. It doesn't make sense to provide
+    /// custom `clock` unless you want to test the object. That's why this
+    /// function is private and not exposed to end users.
+    ///
+    /// [`configure`]: RateLimiter::configure
+    #[inline]
+    fn with_timer(clock: &'a (dyn Fn() -> Instant + Sync)) -> RateLimiterBuilder<'a, K> {
+        RateLimiterBuilder {
+            limits: Vec::new(),
             clock,
         }
     }
+}
 
-    pub fn set_limit(&mut self, key: K, limit: usize, interval: Duration) {
-        self.buckets
-            .insert(key, TokenBucket::with_timer(limit, interval, self.clock));
-    }
-
+impl<'a, K: Eq + Hash> RateLimiter<'a, K> {
+    /// Tries to consume the specified number of `tokens` from the bucket for a
+    /// given event (`key`).
+    ///
+    /// The `consume` function retrieves a bucket for a given `key`, and
+    /// delegates token consumption to [`TokenBucket::consume`] function. Please
+    /// see [`TokenBucket`] documentation for details on what's returned by this
+    /// function.
+    ///
+    /// If not `limit` is set, the `consume` function always succeed.
+    ///
+    /// See [`limit`] for how to setup a limiting policy for a `key`.
+    ///
+    /// [`limit`]: RateLimiterBuilder::limit
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use youshallnotpass::RateLimiter;
+    ///
+    /// let limiter = RateLimiter::configure()
+    ///     .limit("A", 2, Duration::from_secs(60))
+    ///     .done();
+    ///
+    /// assert!(limiter.consume("A", 1).is_ok());
+    /// assert!(limiter.consume("A", 1).is_ok());
+    /// assert!(limiter.consume("A", 1).is_err());
+    ///
+    /// assert!(limiter.consume("B", 1).is_ok());
+    /// ```
     pub fn consume(&self, key: K, tokens: usize) -> Result<(), Error> {
         self.buckets
             .get(&key)
@@ -35,9 +123,40 @@ impl<'a, K: Eq + Hash> RateLimiter<'a, K> {
     }
 }
 
-impl<'a, K: Eq + Hash> Default for RateLimiter<'a, K> {
-    fn default() -> Self {
-        Self::new()
+/// The builder exposes ability to configure a [`RateLimiter`] instance by
+/// setting limiting policies.
+pub struct RateLimiterBuilder<'a, K> {
+    limits: Vec<(K, usize, Duration)>,
+    clock: &'a (dyn Fn() -> Instant + Sync),
+}
+
+impl<'a, K> RateLimiterBuilder<'a, K> {
+    /// Sets a limiting policy for a `key`.
+    ///
+    /// The limiting policy sets how many times an event is allowed to happen
+    /// (`limit`) within a given period of time (`interval`). Event is vague
+    /// term. Thus we use a `key` to uniquely identify an event we want to rate
+    /// limit.
+    pub fn limit(mut self, key: K, limit: usize, interval: Duration) -> Self {
+        self.limits.push((key, limit, interval));
+        self
+    }
+}
+
+impl<'a, K: Eq + Hash> RateLimiterBuilder<'a, K> {
+    /// Constructs a [`RateLimiter`] instance with configured limiting policies.
+    ///
+    /// Once constructed, the `RateLimiter` instance cannot be changed.
+    pub fn done(self) -> RateLimiter<'a, K> {
+        RateLimiter {
+            buckets: self
+                .limits
+                .into_iter()
+                .map(|(key, limit, interval)| {
+                    (key, TokenBucket::with_timer(limit, interval, self.clock))
+                })
+                .collect(),
+        }
     }
 }
 
@@ -48,12 +167,9 @@ mod tests {
 
     #[test]
     fn new() {
-        let mut limiter = RateLimiter::new();
-
-        assert_eq!(limiter.consume("A", 1), Ok(()));
-        assert_eq!(limiter.consume("B", 1), Ok(()));
-
-        limiter.set_limit("A", 3, Duration::from_secs(60));
+        let limiter = RateLimiter::configure()
+            .limit("A", 3, Duration::from_secs(60))
+            .done();
 
         assert_eq!(limiter.consume("A", 1), Ok(()));
         assert_eq!(limiter.consume("A", 1), Ok(()));
@@ -64,15 +180,11 @@ mod tests {
 
     #[test]
     fn blocked_limit() {
-        let mut limiter = RateLimiter::new();
-
-        // requests are alowed when no limit is configured
-        assert_eq!(limiter.consume("A", 1), Ok(()));
-        assert_eq!(limiter.consume("B", 1), Ok(()));
+        let limiter = RateLimiter::configure()
+            .limit("A", 0, Duration::from_secs(60))
+            .done();
 
         // using a limit of 0 blocks the given entity
-        limiter.set_limit("A", 0, Duration::from_secs(60));
-
         assert_eq!(limiter.consume("A", 1), Err(Error::Blocked));
         assert_eq!(limiter.consume("A", 1), Err(Error::Blocked));
         assert_eq!(limiter.consume("A", 1), Err(Error::Blocked));
@@ -80,14 +192,9 @@ mod tests {
 
     #[test]
     fn blocked_duration() {
-        let mut limiter = RateLimiter::new();
-
-        // requests are alowed when no limit is configured
-        assert_eq!(limiter.consume("A", 1), Ok(()));
-        assert_eq!(limiter.consume("B", 1), Ok(()));
-
-        // using an interval of 0 blocks the given entity
-        limiter.set_limit("A", 42, Duration::from_secs(0));
+        let limiter = RateLimiter::configure()
+            .limit("A", 42, Duration::from_secs(0))
+            .done();
 
         assert_eq!(limiter.consume("A", 1), Err(Error::Blocked));
         assert_eq!(limiter.consume("A", 1), Err(Error::Blocked));
@@ -98,9 +205,9 @@ mod tests {
     fn capacity_is_one() {
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
-
-        let mut limiter = RateLimiter::with_timer(&clock);
-        limiter.set_limit("A", 1, Duration::from_secs(1));
+        let limiter = RateLimiter::with_timer(&clock)
+            .limit("A", 1, Duration::from_secs(1))
+            .done();
 
         assert_eq!(limiter.consume("A", 1), Ok(()));
         assert_eq!(
@@ -120,9 +227,9 @@ mod tests {
     fn capacity_gt_one() {
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
-
-        let mut limiter = RateLimiter::with_timer(&clock);
-        limiter.set_limit("A", 3, Duration::from_secs(1));
+        let limiter = RateLimiter::with_timer(&clock)
+            .limit("A", 3, Duration::from_secs(1))
+            .done();
 
         assert_eq!(limiter.consume("A", 1), Ok(()));
         assert_eq!(limiter.consume("A", 1), Ok(()));
@@ -146,9 +253,9 @@ mod tests {
     fn period_gt_one() {
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
-
-        let mut limiter = RateLimiter::with_timer(&clock);
-        limiter.set_limit("A", 1, Duration::from_secs(3));
+        let limiter = RateLimiter::with_timer(&clock)
+            .limit("A", 1, Duration::from_secs(3))
+            .done();
 
         assert_eq!(limiter.consume("A", 1), Ok(()));
         assert_eq!(
@@ -175,9 +282,9 @@ mod tests {
         let t0 = Instant::now();
         let now = Mutex::new(t0);
         let clock = || *now.lock().unwrap();
-
-        let mut limiter = RateLimiter::with_timer(&clock);
-        limiter.set_limit("A", 4, Duration::from_secs(1));
+        let limiter = RateLimiter::with_timer(&clock)
+            .limit("A", 4, Duration::from_secs(1))
+            .done();
 
         // consume first token
         *now.lock().unwrap() = t0;
@@ -229,9 +336,9 @@ mod tests {
     fn consume_gt_one() {
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
-
-        let mut limiter = RateLimiter::with_timer(&clock);
-        limiter.set_limit("A", 3, Duration::from_secs(1));
+        let limiter = RateLimiter::with_timer(&clock)
+            .limit("A", 3, Duration::from_secs(1))
+            .done();
 
         // consume all tokens at once
         assert_eq!(limiter.consume("A", 3), Ok(()));
@@ -267,10 +374,10 @@ mod tests {
     fn multiple_buckets() {
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
-
-        let mut limiter = RateLimiter::with_timer(&clock);
-        limiter.set_limit("A", 2, Duration::from_secs(1));
-        limiter.set_limit("B", 1, Duration::from_secs(2));
+        let limiter = RateLimiter::with_timer(&clock)
+            .limit("A", 2, Duration::from_secs(1))
+            .limit("B", 1, Duration::from_secs(2))
+            .done();
 
         // consume tokens in A and B
         assert_eq!(limiter.consume("A", 1), Ok(()));
@@ -323,11 +430,11 @@ mod tests {
 
         let now = Mutex::new(Instant::now());
         let clock = || *now.lock().unwrap();
-
-        let mut limiter = RateLimiter::with_timer(&clock);
-        limiter.set_limit((MyHttpVerb::PUT, "/foobar"), 1, Duration::from_secs(1));
-        limiter.set_limit((MyHttpVerb::GET, "/foobar"), 3, Duration::from_secs(1));
-        limiter.set_limit((MyHttpVerb::GET, "/spam"), 2, Duration::from_secs(1));
+        let limiter = RateLimiter::with_timer(&clock)
+            .limit((MyHttpVerb::PUT, "/foobar"), 1, Duration::from_secs(1))
+            .limit((MyHttpVerb::GET, "/foobar"), 3, Duration::from_secs(1))
+            .limit((MyHttpVerb::GET, "/spam"), 2, Duration::from_secs(1))
+            .done();
 
         assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), Ok(()));
         assert_eq!(limiter.consume((MyHttpVerb::GET, "/foobar"), 1), Ok(()));


### PR DESCRIPTION
The RateLimiter structure stores token bucket instances in a hash map that is not thread-safe. Instead of making a RateLimiter instance thread-safe, we decided to prevent it from being changed after it has been constructed. This patch implements the builder pattern for rate limiters making it one and only way to construct it.